### PR TITLE
React Native Android SDK Checks

### DIFF
--- a/extensions/helpers/addOptionalRules.js
+++ b/extensions/helpers/addOptionalRules.js
@@ -15,9 +15,8 @@ module.exports = (context, requirements) => {
     {rule: 'cli', binary: 'applesimutils', error: 'Try `brew install --HEAD applesimutils`', platform: 'darwin'}
   ]
   const android = [
-    { rule: 'cli', binary: 'emulator' },
-    { rule: 'cli', binary: 'android' },
-    { rule: 'env', variable: 'ANDROID_HOME', error: 'The ANDROID_HOME environment variable must be set to your local SDK.  Refer to getting started docs for help.' }
+    { rule: 'env', variable: 'ANDROID_HOME', error: 'The ANDROID_HOME environment variable must be set to your local SDK.  Refer to getting started docs for help.' },
+    { rule: 'custom', plugin: 'React Native', name: 'androidVersion' }
   ]
   const xcode = [
     { rule: 'cli', binary: 'xcodebuild', semver: '0.0', platform: 'darwin' },

--- a/extensions/helpers/getAndroidEnvData.js
+++ b/extensions/helpers/getAndroidEnvData.js
@@ -1,0 +1,18 @@
+module.exports = (context) => {
+  const { envInfo, filesystem } = context
+  // Version specified by RN project settings
+  const androidGradle = filesystem.read('./android/app/build.gradle')
+  const androidData = envInfo.getAllAndroidSDKs()
+
+  if (androidGradle) {
+    return {
+      androidGradle,
+      availableApiVersions: androidData['API Levels'],
+      availableBuildToolsVersions: androidData['Build Tools'],
+      projectApiVersion: /compileSdkVersion\s(\d+)/.exec(androidGradle)[1],
+      projectBuildToolsVersion: /buildToolsVersion\s\"([\d|.]+)\"/.exec(androidGradle)[1]
+    }
+  } else {
+    return { androidGradle: null }
+  }
+}

--- a/extensions/react-native.js
+++ b/extensions/react-native.js
@@ -1,4 +1,5 @@
 const addOptionalRules = require('./helpers/addOptionalRules')
+const getAndroidEnvData = require('./helpers/getAndroidEnvData')
 
 module.exports = (context) => {
   // Register this plugin
@@ -14,6 +15,69 @@ module.exports = (context) => {
       context.solidarity.setSolidaritySettings(solidarity, context)
       // update file with local versions
       await context.system.run('solidarity snapshot')
-    }
+    },
+    rules: {
+      androidVersion: {
+        check: async (rule, context) => {
+          const {
+            androidGradle,
+            availableApiVersions,
+            availableBuildToolsVersions,
+            projectApiVersion,
+            projectBuildToolsVersion
+          } = getAndroidEnvData(context)
+
+          if (androidGradle) {
+            const buildGood = availableBuildToolsVersions.includes(projectBuildToolsVersion)
+            const apiGood = availableApiVersions.includes(projectApiVersion)
+            if (buildGood && apiGood) {
+              return {
+                pass: true,
+                message: `Android API ${projectApiVersion} & Build Tools ${projectBuildToolsVersion}`
+              }
+            } else {
+              let failMessages = []
+              if (!buildGood) failMessages.push(`Build Tool ${projectBuildToolsVersion} Not Found`)
+              if (!apiGood) failMessage.push(`API ${projectApiVersion} Not Found`)
+              return {
+                pass: false,
+                message: failMessages.join(' & ')
+              }
+            }
+          } else {
+            return {
+              pass: false,
+              message: './android/app/build.gradle not found'
+            }
+          }
+        },
+        report: async (rule, context, report) => {
+          const { print } = context
+          const { colors } = print
+          const {
+            androidGradle,
+            availableApiVersions,
+            availableBuildToolsVersions,
+            projectApiVersion,
+            projectBuildToolsVersion
+          } = getAndroidEnvData(context)
+
+          const projectAPIMessage = availableApiVersions.includes(projectApiVersion)
+            ? colors.green(`API ${projectApiVersion} Available`)
+            : colors.red(`API ${projectApiVersion} Unavailable`)
+
+          const projectBuildToolsMessage = availableBuildToolsVersions.includes(projectBuildToolsVersion)
+            ? colors.green(`Build Tools ${projectBuildToolsVersion} Available`)
+            : colors.red(`Build Tools ${projectBuildToolsVersion} Unavailable`)
+
+          report.customRules.push({
+            title: 'Android SDK',
+            table: [
+              ['Project API Version', 'Project Build Tools'],
+              [projectAPIMessage, projectBuildToolsMessage],
+            ]
+          })
+        }
+      }
   })
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test": "echo not yet",
     "shipit": "np"
   },
+  "peerDependencies": {
+    "solidarity": "^2.0.0"
+  },
   "devDependencies": {
     "np": "^2.16.0"
   }


### PR DESCRIPTION
## TL:DR;
This plugin now makes sure your project and your Android SDKs are good.

### Solidarity Check:  With Android Rule
checks the React Native API and BuildTools to make sure they exist on the system.

### Snapshot:  Not needed
Since the version is identified in the RN project, no need to change or modify the rule versions.  This makes life simple for everyone.

Implements custom rule for Android SDK version checks on API/Build Tools

### Report:
Identifies RN project API and BuildTool version, and if it exists on the machine
<img width="818" alt="screen shot 2018-02-14 at 9 44 45 pm" src="https://user-images.githubusercontent.com/997157/36239698-4accfdfa-11d1-11e8-9a6a-895014a3b8ef.png">

Availability check thanks to incoming API from envinfo

### Rule example:
```json
    "Android SDK Check": [
      {
        "rule": "custom",
        "plugin": "React Native",
        "name": "androidVersion"
      }
    ]
```

-------
closes #17 