### PR TITLE
fix errors with android in newer react native versions

### DIFF
--- a/extensions/helpers/getAndroidEnvData.js
+++ b/extensions/helpers/getAndroidEnvData.js
@@ -1,18 +1,33 @@
-module.exports = (context) => {
-  const { envInfo, filesystem } = context
-  // Version specified by RN project settings
-  const androidGradle = filesystem.read('./android/app/build.gradle')
-  const androidData = envInfo.getAllAndroidSDKs()
-
-  if (androidGradle) {
-    return {
-      androidGradle,
-      availableApiVersions: androidData['API Levels'],
-      availableBuildToolsVersions: androidData['Build Tools'],
-      projectApiVersion: /compileSdkVersion\s(\d+)/.exec(androidGradle)[1],
-      projectBuildToolsVersion: /buildToolsVersion\s["|']([\d|.]+)["|']/.exec(androidGradle)[1]
-    }
-  } else {
-    return { androidGradle: null }
+const executeRegexOnFiles = (regex, files) => {
+  for (let file of files) {
+    try {
+      return regex.exec(file)[1];
+    } catch (e) {}
   }
-}
+};
+
+module.exports = context => {
+  const { envInfo, filesystem } = context;
+  // Version specified by RN project settings
+  const androidAppGradle = filesystem.read("./android/app/build.gradle");
+  const androidGradle = filesystem.read("./android/build.gradle");
+  const androidData = envInfo.getAllAndroidSDKs();
+
+  if (androidAppGradle) {
+    return {
+      androidAppGradle,
+      availableApiVersions: androidData["API Levels"],
+      availableBuildToolsVersions: androidData["Build Tools"],
+      projectApiVersion: executeRegexOnFiles(/compileSdkVersion\s=?\s?(\d+)/, [
+        androidAppGradle,
+        androidGradle
+      ]),
+      projectBuildToolsVersion: executeRegexOnFiles(
+        /buildToolsVersion\s=?\s?["|']([\d|.]+)["|']/,
+        [androidAppGradle, androidGradle]
+      )
+    };
+  } else {
+    return { androidAppGradle: null };
+  }
+};

--- a/extensions/react-native.js
+++ b/extensions/react-native.js
@@ -1,84 +1,94 @@
-const addOptionalRules = require('./helpers/addOptionalRules')
-const getAndroidEnvData = require('./helpers/getAndroidEnvData')
+const addOptionalRules = require("./helpers/addOptionalRules");
+const getAndroidEnvData = require("./helpers/getAndroidEnvData");
 
-module.exports = (context) => {
+module.exports = context => {
   // Register this plugin
   context.addPlugin({
-    name: 'React Native',
-    description: 'Snapshot solidarity rules for React Native projects',
-    snapshot: async (context) => {
+    name: "React Native",
+    description: "Snapshot solidarity rules for React Native projects",
+    snapshot: async context => {
       // start with template
-      let solidarity = require('../templates/react-native-template.json')
+      let solidarity = require("../templates/react-native-template.json");
       // add optional rules
-      addOptionalRules(context, solidarity.requirements)
+      addOptionalRules(context, solidarity.requirements);
       // write out .solidarity file
-      context.solidarity.setSolidaritySettings(solidarity, context)
+      context.solidarity.setSolidaritySettings(solidarity, context);
       // update file with local versions
-      await context.system.run('solidarity snapshot')
+      await context.system.run("solidarity snapshot");
     },
     rules: {
       androidVersion: {
         check: async (rule, context) => {
           const {
-            androidGradle,
+            androidAppGradle,
             availableApiVersions,
             availableBuildToolsVersions,
             projectApiVersion,
             projectBuildToolsVersion
-          } = getAndroidEnvData(context)
+          } = getAndroidEnvData(context);
 
-          if (androidGradle) {
-            const buildGood = availableBuildToolsVersions.includes(projectBuildToolsVersion)
-            const apiGood = availableApiVersions.includes(projectApiVersion)
+          if (androidAppGradle) {
+            const buildGood = availableBuildToolsVersions.includes(
+              projectBuildToolsVersion
+            );
+            const apiGood = availableApiVersions.includes(projectApiVersion);
             if (buildGood && apiGood) {
               return {
                 pass: true,
                 message: `Android API ${projectApiVersion} & Build Tools ${projectBuildToolsVersion}`
-              }
+              };
             } else {
-              let failMessages = []
-              if (!buildGood) failMessages.push(`Build Tool ${projectBuildToolsVersion} Not Found`)
-              if (!apiGood) failMessages.push(`API ${projectApiVersion} Not Found`)
+              let failMessages = [];
+              if (!buildGood)
+                failMessages.push(
+                  `Build Tool ${projectBuildToolsVersion} Not Found`
+                );
+              if (!apiGood)
+                failMessages.push(`API ${projectApiVersion} Not Found`);
               return {
                 pass: false,
-                message: failMessages.join(' & ')
-              }
+                message: failMessages.join(" & ")
+              };
             }
           } else {
             return {
               pass: false,
-              message: './android/app/build.gradle not found'
-            }
+              message: "./android/app/build.gradle not found"
+            };
           }
         },
         report: async (rule, context, report) => {
-          const { print } = context
-          const { colors } = print
+          const { print } = context;
+          const { colors } = print;
           const {
-            androidGradle,
+            androidAppGradle,
             availableApiVersions,
             availableBuildToolsVersions,
             projectApiVersion,
             projectBuildToolsVersion
-          } = getAndroidEnvData(context)
+          } = getAndroidEnvData(context);
 
-          const projectAPIMessage = availableApiVersions.includes(projectApiVersion)
+          const projectAPIMessage = availableApiVersions.includes(
+            projectApiVersion
+          )
             ? colors.green(`API ${projectApiVersion} Available`)
-            : colors.red(`API ${projectApiVersion} Unavailable`)
+            : colors.red(`API ${projectApiVersion} Unavailable`);
 
-          const projectBuildToolsMessage = availableBuildToolsVersions.includes(projectBuildToolsVersion)
+          const projectBuildToolsMessage = availableBuildToolsVersions.includes(
+            projectBuildToolsVersion
+          )
             ? colors.green(`Build Tools ${projectBuildToolsVersion} Available`)
-            : colors.red(`Build Tools ${projectBuildToolsVersion} Unavailable`)
+            : colors.red(`Build Tools ${projectBuildToolsVersion} Unavailable`);
 
           report.customRules.push({
-            title: 'Android SDK',
+            title: "Android SDK",
             table: [
-              ['Project API Version', 'Project Build Tools'],
-              [projectAPIMessage, projectBuildToolsMessage],
+              ["Project API Version", "Project Build Tools"],
+              [projectAPIMessage, projectBuildToolsMessage]
             ]
-          })
+          });
         }
       }
     }
-  })
-}
+  });
+};


### PR DESCRIPTION
Newer RN versions use the

```gradle
android {
    compileSdkVersion rootProject.ext.compileSdkVersion
    buildToolsVersion rootProject.ext.buildToolsVersion
}
```
syntax which was not supported and lead to an immediate exit.

Without the fix this error got thrown:

```
TypeError: Cannot read property '1' of null
    at module.exports (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/solidarity-react-native/extensions/helpers/getAndroidEnvData.js:12:72)
    at Object.check (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/solidarity-react-native/extensions/react-native.js:28:15)
    at Object.<anonymous> (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/solidarity/dist/extensions/functions/checkRequirement.js:124:72)
    at Generator.next (<anonymous>)
    at /Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/solidarity/dist/extensions/functions/checkRequirement.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/solidarity/dist/extensions/functions/checkRequirement.js:3:12)
    at map (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/solidarity/dist/extensions/functions/checkRequirement.js:62:44)
    at _map (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/ramda/src/internal/_map.js:6:19)
    at map (/Users/danielschmidt/projects/private/solidaritydemoproject/node_modules/ramda/src/map.js:64:14)
```

My prettier went a bit through the roof, if that's not cool I can redo the changes without prettier being active.