### PR TITLE
Fix basic rule logic, typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ By using this plugin to solidarity, you can snapshot your environment to verify 
 ```bash
 npm i -g solidarity-react-native
 # or
-yarn add global solidarity-react-native
+yarn global add solidarity-react-native
 
 # go to your react native project and run:
 solidarity snapshot

--- a/extensions/helpers/getAndroidEnvData.js
+++ b/extensions/helpers/getAndroidEnvData.js
@@ -16,13 +16,15 @@ module.exports = async context => {
 
   const androidAppGradle = await filesystem.readAsync(appGradlePath)
   const androidGradle = await filesystem.readAsync(gradlePath)
-  const androidData = await envinfo.getAndroidSDKInfo()
+  const androidSDKInfo = await envinfo.getAndroidSDKInfo();
+  // to get the object - the first item is the string 'Android SDK'
+  const androidData = androidSDKInfo[1];
 
   if (androidAppGradle) {
     return {
       androidAppGradle,
-      availableApiVersions: androidData[1]["API Levels"],
-      availableBuildToolsVersions: androidData[1]["Build Tools"],
+      availableApiVersions: androidData["API Levels"],
+      availableBuildToolsVersions: androidData["Build Tools"],
       projectApiVersion: executeRegexOnFiles(/compileSdkVersion\s=?\s?(\d+)/, [
         androidAppGradle,
         androidGradle

--- a/extensions/react-native.js
+++ b/extensions/react-native.js
@@ -27,7 +27,6 @@ module.exports = context => {
             projectBuildToolsVersion
           } = await getAndroidEnvData(context);
 
-
           if (androidAppGradle) {
             const buildGood = availableBuildToolsVersions.includes(
               projectBuildToolsVersion
@@ -66,8 +65,7 @@ module.exports = context => {
             availableBuildToolsVersions,
             projectApiVersion,
             projectBuildToolsVersion
-          } = await getAndroidEnvData(context)
-
+          } = await getAndroidEnvData(context);
 
           const projectAPIMessage = availableApiVersions.includes(
             projectApiVersion


### PR DESCRIPTION
I cannot get the ANDROID_HOME env rule to pass. I notice that `ANDROID_HOME` is [optional](https://github.com/tabrindle/envinfo/blob/81d4ffd38f13ed7d1889dee194321c3e8e2c5892/src/helpers.js#L31) in [envinfo](https://github.com/tabrindle/envinfo), but I'm not sure what I can do to fix this rule, since I don't have the ANDROID_HOME path set up on my system.

If I delete the ANDROID_HOME env rule, I can get it working. The React Native custom rule now runs.

In `react-native.js`:

* added `await` because `getAndroidEnvData()` returns a Promise. This fixes the `./android/app/build.gradle not found` error.

* I cannot get the `report` section of this rule to print when I run `solidarity report`

In `getAndroidEnvData.js`:

* I updated `androidData` to make it more clear where the object is coming from.
`getAndroidSDKInfo()` returns the array 
```
[ 'Android SDK',
  { 'API Levels': [... ],
    'Build Tools': [ ... ],
    'System Images': [ ... ],
   }
 ]
```

README typo fix:
* `yarn add global solidarity-react-native` => `yarn global add solidarity-react-native`